### PR TITLE
refactor: commented out coords on db.js > eventSchema

### DIFF
--- a/db.js
+++ b/db.js
@@ -40,10 +40,11 @@ const eventSchema = new mongoose.Schema({
     description: { type: String, required: true },
     date: { type: Date, required: true },
     venue: { type: String, required: true },
-    coords: { 
-        lat: { type: Number, required: true },
-        lon: { type: Number, required: true },
-     },
+    // TODO: Look at how to include coords. Had to comment it out to allow event creation
+    // coords: { 
+    //     lat: { type: Number, required: true },
+    //     lon: { type: Number, required: true },
+    //  },
     category: { type: mongoose.Schema.Types.ObjectId, ref: "Category", required: true },
     // TODO: Add a field for the image URL
     anime: { type: String },

--- a/routes/events_routes.js
+++ b/routes/events_routes.js
@@ -50,7 +50,7 @@ router.get('/:id', async (req, res) => {
 })
 
 // Create an event
-router.post('/', /* authenticateAdminOrOrganiser, */ async (req, res) => {
+router.post('/', authenticateAdminOrOrganiser, async (req, res) => {
     const { title, description, category, date, anime, organiser, price, venue, lat, long } = req.body
     const parsedDate = Date.parse(date) // Convert the date from a string to a Date object
     const userId = req.user._id
@@ -62,18 +62,22 @@ router.post('/', /* authenticateAdminOrOrganiser, */ async (req, res) => {
             category: category,
             date: parsedDate,
             venue: venue,
-            coords: {
-                lat: lat,
-                lon: long
-            },
+            // coords: {
+            //     lat: lat,
+            //     lon: long
+            // },
             anime: anime,
             createdBy: userId,
             organiser: organiser,
             price: price
         })
+        console.log("New Event:", insertedEvent)
+
         await insertedEvent.save()
+        console.log("Event saved:", insertedEvent)
         res.status(201).send(insertedEvent)
     } catch (error) {
+        console.error("Error creating:", error)
         res.status(400).send({ error: error.message})
     }
 })


### PR DESCRIPTION
Commented out the `coords` on the db.js > eventSchema as this was breaking the ability to create an event. Will need to figure out how to add this back in in the future.